### PR TITLE
Added profile customization prop to User entity for preferred dashboard

### DIFF
--- a/src/main/java/com/bootcamp/blackbriar/controller/UserController.java
+++ b/src/main/java/com/bootcamp/blackbriar/controller/UserController.java
@@ -5,10 +5,7 @@ import com.bootcamp.blackbriar.service.user.UserService;
 import com.bootcamp.blackbriar.model.group.GroupEntity;
 import com.bootcamp.blackbriar.model.group.InstructorGroupResponse;
 import com.bootcamp.blackbriar.model.group.StudentGroupResponse;
-import com.bootcamp.blackbriar.model.user.UserDetailsRequestModel;
-import com.bootcamp.blackbriar.model.user.UserDto;
-import com.bootcamp.blackbriar.model.user.UserEntity;
-import com.bootcamp.blackbriar.model.user.UserRest;
+import com.bootcamp.blackbriar.model.user.*;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.springframework.beans.BeanUtils;
@@ -31,10 +28,10 @@ public class UserController {
   ModelMapper modelMapper;
 
   @GetMapping(value = "/{userId}")
-  public UserRest getUser(@PathVariable String userId) {
+  public UserProfile getUser(@PathVariable String userId) {
     UserEntity user = userService.getUserByPublicId(userId);
 
-    return modelMapper.map(user, UserRest.class);
+    return modelMapper.map(user, UserProfile.class);
   }
 
   @GetMapping(value = "/{instructorUserId}/groups/owned")
@@ -63,8 +60,8 @@ public class UserController {
   }
 
   @PostMapping
-  public UserRest createUser(@RequestBody UserDetailsRequestModel userDetails) {
-    UserRest returnValue = new UserRest();
+  public UserProfile createUser(@RequestBody UserDetailsRequestModel userDetails) {
+    UserProfile returnValue = new UserProfile();
     UserDto userDto = new UserDto();
 
     BeanUtils.copyProperties(userDetails, userDto);

--- a/src/main/java/com/bootcamp/blackbriar/model/user/GroupMemberResponse.java
+++ b/src/main/java/com/bootcamp/blackbriar/model/user/GroupMemberResponse.java
@@ -5,9 +5,6 @@ import com.bootcamp.blackbriar.model.membership.MembershipEntity;
 
 import org.springframework.beans.BeanUtils;
 
-/**
- * GroupMemberResponse
- */
 public class GroupMemberResponse {
   private String firstName;
   private String lastName;

--- a/src/main/java/com/bootcamp/blackbriar/model/user/UserDto.java
+++ b/src/main/java/com/bootcamp/blackbriar/model/user/UserDto.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 public class UserDto implements Serializable {
   private static final long serialVersionUID = -6546925859137218064L;
+
   private long id;
   private String userId;
   private String encryptedPassword;
@@ -13,6 +14,8 @@ public class UserDto implements Serializable {
   private String password;
   private String firstName;
   private String lastName;
+  private boolean isStudent = true;
+
   private String photo = "anon.jpg";
 
   public long getId() {
@@ -93,5 +96,13 @@ public class UserDto implements Serializable {
 
   public void setPhoto(String photo) {
     this.photo = photo;
+  }
+
+  public boolean isStudent() {
+    return isStudent;
+  }
+
+  public void setStudent(boolean isStudent) {
+    this.isStudent = isStudent;
   }
 }

--- a/src/main/java/com/bootcamp/blackbriar/model/user/UserEntity.java
+++ b/src/main/java/com/bootcamp/blackbriar/model/user/UserEntity.java
@@ -38,6 +38,9 @@ public class UserEntity implements Serializable {
   private String photo = "anon.jpg";
 
   @Column(nullable = false)
+  private boolean isStudent = true;
+
+  @Column(nullable = false)
   private String encryptedPassword;
 
   private String emailVerificationToken;
@@ -131,5 +134,13 @@ public class UserEntity implements Serializable {
 
   public void setStudyGroups(List<MembershipEntity> studyGroups) {
     this.studyGroups = studyGroups;
+  }
+
+  public boolean isStudent() {
+    return isStudent;
+  }
+
+  public void setStudent(boolean isStudent) {
+    this.isStudent = isStudent;
   }
 }

--- a/src/main/java/com/bootcamp/blackbriar/model/user/UserLoginRest.java
+++ b/src/main/java/com/bootcamp/blackbriar/model/user/UserLoginRest.java
@@ -1,5 +1,6 @@
 package com.bootcamp.blackbriar.model.user;
 
+// TODO: Remove this class; it's not being used...
 public class UserLoginRest {
   private String userId;
   private String firstName;

--- a/src/main/java/com/bootcamp/blackbriar/model/user/UserProfile.java
+++ b/src/main/java/com/bootcamp/blackbriar/model/user/UserProfile.java
@@ -1,19 +1,19 @@
 package com.bootcamp.blackbriar.model.user;
 
-public class UserDetailsRequestModel {
-  private String password;
+public class UserProfile {
+  private String userId;
   private String firstName;
   private String lastName;
   private String email;
-  private String photo = "anon.jpg";
+  private String photo;
   private boolean isStudent = true;
 
-  public String getPassword() {
-    return password;
+  public String getUserId() {
+    return userId;
   }
 
-  public void setPassword(String password) {
-    this.password = password;
+  public void setUserId(String userId) {
+    this.userId = userId;
   }
 
   public String getFirstName() {

--- a/src/main/java/com/bootcamp/blackbriar/service/user/UserServiceImpl.java
+++ b/src/main/java/com/bootcamp/blackbriar/service/user/UserServiceImpl.java
@@ -28,6 +28,7 @@ public class UserServiceImpl implements UserService {
   @Autowired
   Utils utils;
 
+  // TODO: Clean this mess of property copying
   @Override
   public UserDto createUser(UserDto user) {
     if (userRepository.findByEmail(user.getEmail()) != null) {


### PR DESCRIPTION
The frontend can now send an additional JSON property called `student` when making a new account (it defaults to `true`) which makes them able to choose their preferred dashboard after login: student or instructor. This property is also returned when querying for the user profile endpoint at `/users/{id}`.